### PR TITLE
Feature/issues 22

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name"
-            android:theme="@style/AppTheme.NoActionBar">
+            android:theme="@style/AppTheme.NoActionBar"
+            android:configChanges="orientation|screenSize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/mycroft/ai/MainActivity.java
+++ b/app/src/main/java/mycroft/ai/MainActivity.java
@@ -87,8 +87,7 @@ public class MainActivity extends AppCompatActivity {
         });
 
         voxSwitch = (Switch) findViewById(R.id.voxswitch);
-        //set the switch to ON
-        voxSwitch.setChecked(true);
+
         //attach a listener to check for changes in state
         voxSwitch.setOnCheckedChangeListener(new OnCheckedChangeListener() {
 
@@ -304,9 +303,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onStart() {
         super.onStart();
-
         loadPreferences();
-
         registerReceiver();
     }
 
@@ -319,9 +316,7 @@ public class MainActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
-
         loadPreferences();
-
         registerReceiver();
     }
 


### PR DESCRIPTION
used android:configChanges="orientation|screenSize" setting to ensure view is not recreated on orientation change. We may need to revisit this as an enhancement down the road if we decide we want a different layout in landscape mode. Also snuck in a small change, removed the line that was setting voxSwitch checked to true. When prefs are loaded it will pick up the last state.
