### PR TITLE
fix at least one reason for issue #55

### DIFF
--- a/mobile/src/main/java/mycroft/ai/MainActivity.java
+++ b/mobile/src/main/java/mycroft/ai/MainActivity.java
@@ -538,6 +538,9 @@ public class MainActivity extends AppCompatActivity  {
     @Override
     public void onRequestPermissionsResult(int requestCode,
                                            String permissions[], int[] grantResults) {
+        if ( grantResults.length == 0 )
+            return;
+
         switch (requestCode) {
             case PERMISSION_REQUEST_COARSE_LOCATION: {
                 if (grantResults[0] == PackageManager.PERMISSION_GRANTED) {


### PR DESCRIPTION
There are other problems that may cause crashes at startup.  I am unhappy that beacon scanning starts before permission is actually granted. However this commit fixes the case where onRequestPermissionResult  assumes a return in grantResults.